### PR TITLE
Add Google Sheet live data sync + Daily Scan tab

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,6 +10,7 @@ import {
   ClipboardList,
   Users,
   AlertTriangle,
+  Inbox,
 } from 'lucide-react';
 import Overview from '@/components/Overview';
 import RoleHealth from '@/components/RoleHealth';
@@ -19,13 +20,15 @@ import KPIs from '@/components/KPIs';
 import WeeklyReport from '@/components/WeeklyReport';
 import Candidates from '@/components/Candidates';
 import ErrorLog from '@/components/ErrorLog';
+import DailyScan from '@/components/DailyScan';
 
-type Tab = 'overview' | 'health' | 'emails' | 'jds' | 'kpis' | 'report' | 'candidates' | 'errorlog';
+type Tab = 'overview' | 'health' | 'emails' | 'scan' | 'jds' | 'kpis' | 'report' | 'candidates' | 'errorlog';
 
 const tabs: { id: Tab; label: string; icon: typeof LayoutDashboard; badge?: number }[] = [
   { id: 'overview', label: 'Overview', icon: LayoutDashboard },
   { id: 'health', label: 'Role Health', icon: HeartPulse, badge: 47 },
   { id: 'emails', label: 'Intro Emails', icon: Mail, badge: 131 },
+  { id: 'scan', label: 'Daily Scan', icon: Inbox },
   { id: 'jds', label: 'JD Tracker', icon: FileText, badge: 38 },
   { id: 'kpis', label: 'KPIs', icon: Target },
   { id: 'report', label: 'Weekly Report', icon: ClipboardList },
@@ -41,6 +44,7 @@ export default function Home() {
       case 'overview': return <Overview />;
       case 'health': return <RoleHealth />;
       case 'emails': return <IntroEmails />;
+      case 'scan': return <DailyScan />;
       case 'jds': return <JDTracker />;
       case 'kpis': return <KPIs />;
       case 'report': return <WeeklyReport />;

--- a/components/DailyScan.tsx
+++ b/components/DailyScan.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getStorage, setStorage } from '@/lib/storage';
+import { Save, Trash2, ClipboardCopy, ChevronDown, ChevronRight, FileText } from 'lucide-react';
+
+const SCANS_KEY = 'cc_daily_scans';
+
+interface Scan {
+  id: string;
+  date: string;
+  content: string;
+  stats: {
+    replied: number;
+    pending: number;
+    needsFU: number;
+  };
+}
+
+const SAMPLE_REPORT = `# Contrario Daily Inbox Scan
+Date: ${new Date().toISOString().split('T')[0]}
+
+## Summary
+- Total threads scanned (last 14 days): 131
+- Replied: —
+- Pending (<3 days): —
+- Needs Follow-Up (3+ days, no reply): —
+
+## Needs Follow-Up Today (Round 1)
+- [Candidate] — [Role] @ [Company] — sent 3 days ago
+
+## Needs Follow-Up Today (Round 2)
+- [Candidate] — [Role] @ [Company] — sent 6 days ago
+
+## Needs Follow-Up Today (Round 3 — new thread)
+- [Candidate] — [Role] @ [Company] — sent 9 days ago
+
+## Drafts Created
+- [Count] follow-up drafts created in Gmail
+
+## Notes
+- [Any anomalies or blockers]
+`;
+
+export default function DailyScan() {
+  const [scans, setScans] = useState<Scan[]>([]);
+  const [content, setContent] = useState(SAMPLE_REPORT);
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [copied, setCopied] = useState<string | null>(null);
+
+  useEffect(() => {
+    setScans(getStorage<Scan[]>(SCANS_KEY, []));
+  }, []);
+
+  function extractStats(text: string): Scan['stats'] {
+    const replied = parseInt(text.match(/Replied[:\s]+(\d+)/i)?.[1] || '0', 10);
+    const pending = parseInt(text.match(/Pending[^:]*:\s*(\d+)/i)?.[1] || '0', 10);
+    const needsFU = parseInt(text.match(/Needs Follow[- ]Up[^:]*:\s*(\d+)/i)?.[1] || '0', 10);
+    return { replied, pending, needsFU };
+  }
+
+  function save() {
+    if (!content.trim()) return;
+    const scan: Scan = {
+      id: Date.now().toString(36),
+      date: new Date().toISOString().split('T')[0],
+      content,
+      stats: extractStats(content),
+    };
+    const next = [scan, ...scans];
+    setScans(next);
+    setStorage(SCANS_KEY, next);
+    setContent(SAMPLE_REPORT);
+  }
+
+  function remove(id: string) {
+    const next = scans.filter((s) => s.id !== id);
+    setScans(next);
+    setStorage(SCANS_KEY, next);
+  }
+
+  async function copy(scan: Scan) {
+    await navigator.clipboard.writeText(scan.content);
+    setCopied(scan.id);
+    setTimeout(() => setCopied(null), 2000);
+  }
+
+  const latest = scans[0];
+
+  return (
+    <div className="space-y-4">
+      <div className="bg-card border border-border rounded-2xl p-4">
+        <div className="flex items-start justify-between mb-3">
+          <div>
+            <h3 className="text-sm font-semibold flex items-center gap-2">
+              <FileText size={14} /> Paste Today's Daily Scan
+            </h3>
+            <p className="text-[11px] text-muted mt-1">
+              Run the n8n workflow or the Claude Code inbox scan, then paste the output report here. Stats auto-extract from the "Replied / Pending / Needs Follow-Up" lines.
+            </p>
+          </div>
+          <button
+            onClick={save}
+            className="flex items-center gap-1 bg-accent/20 text-accent px-3 py-1.5 rounded-full text-xs font-medium hover:bg-accent/30"
+          >
+            <Save size={12} /> Save Scan
+          </button>
+        </div>
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          rows={16}
+          className="w-full bg-border/50 border border-border rounded-lg px-3 py-2 text-xs text-fg font-mono focus:border-accent focus:outline-none"
+        />
+      </div>
+
+      {latest && (
+        <div className="grid grid-cols-3 gap-3">
+          <div className="bg-card border border-border rounded-2xl p-4">
+            <p className="text-[10px] text-muted uppercase tracking-wider">Latest Scan · {latest.date}</p>
+            <p className="text-2xl font-bold text-healthy mt-1">{latest.stats.replied}</p>
+            <p className="text-xs text-muted">Replied</p>
+          </div>
+          <div className="bg-card border border-border rounded-2xl p-4">
+            <p className="text-[10px] text-muted uppercase tracking-wider">Pending</p>
+            <p className="text-2xl font-bold text-attention mt-1">{latest.stats.pending}</p>
+            <p className="text-xs text-muted">&lt; 3 days</p>
+          </div>
+          <div className="bg-card border border-border rounded-2xl p-4">
+            <p className="text-[10px] text-muted uppercase tracking-wider">Needs FU</p>
+            <p className="text-2xl font-bold text-risk mt-1">{latest.stats.needsFU}</p>
+            <p className="text-xs text-muted">3+ days no reply</p>
+          </div>
+        </div>
+      )}
+
+      <div>
+        <h3 className="text-sm font-semibold mb-3">Scan History ({scans.length})</h3>
+        {scans.length === 0 ? (
+          <div className="bg-card border border-border rounded-2xl p-8 text-center">
+            <p className="text-sm text-muted">No scans saved yet. Paste one above to get started.</p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {scans.map((scan) => {
+              const isOpen = expanded === scan.id;
+              return (
+                <div key={scan.id} className="bg-card border border-border rounded-2xl overflow-hidden">
+                  <div className="flex items-center justify-between px-4 py-3">
+                    <button
+                      onClick={() => setExpanded(isOpen ? null : scan.id)}
+                      className="flex items-center gap-2 flex-1 min-w-0 text-left"
+                    >
+                      {isOpen ? <ChevronDown size={14} className="text-muted" /> : <ChevronRight size={14} className="text-muted" />}
+                      <span className="text-sm font-mono text-fg">{scan.date}</span>
+                      <span className="text-[10px] text-muted ml-auto mr-3 flex gap-3">
+                        <span className="text-healthy">{scan.stats.replied} replied</span>
+                        <span className="text-attention">{scan.stats.pending} pending</span>
+                        <span className="text-risk">{scan.stats.needsFU} FU</span>
+                      </span>
+                    </button>
+                    <div className="flex items-center gap-2 shrink-0">
+                      <button onClick={() => copy(scan)} className="text-muted hover:text-fg" title="Copy to clipboard">
+                        {copied === scan.id ? <Check size={12} /> : <ClipboardCopy size={12} />}
+                      </button>
+                      <button onClick={() => remove(scan.id)} className="text-muted hover:text-risk">
+                        <Trash2 size={12} />
+                      </button>
+                    </div>
+                  </div>
+                  {isOpen && (
+                    <pre className="px-4 pb-4 text-[11px] font-mono text-muted whitespace-pre-wrap border-t border-border bg-bg/40 pt-3 max-h-96 overflow-y-auto">
+                      {scan.content}
+                    </pre>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Check({ size }: { size: number }) {
+  return <span className="text-healthy text-[10px] leading-none" style={{ fontSize: size }}>✓</span>;
+}

--- a/components/IntroEmails.tsx
+++ b/components/IntroEmails.tsx
@@ -1,17 +1,75 @@
 'use client';
 
-import { useMemo, useState } from 'react';
-import { introEmails } from '@/data/emails';
+import { useEffect, useMemo, useState } from 'react';
+import { introEmails, type IntroEmail } from '@/data/emails';
 import { addBusinessDays, formatDate, daysBetween, REF_DATE, isOverdue } from '@/lib/dateUtils';
+import { fetchSheetCSV } from '@/lib/sheetFetch';
+import { getStorage, setStorage } from '@/lib/storage';
 import StatCard from './StatCard';
+import { RefreshCw, Settings, Check, Link2, Loader2 } from 'lucide-react';
+
+const SHEET_URL_KEY = 'cc_sheet_url';
+const SHEET_DATA_KEY = 'cc_sheet_data';
+const SHEET_UPDATED_KEY = 'cc_sheet_updated';
 
 export default function IntroEmails() {
   const [filter, setFilter] = useState<'all' | 'no-reply' | 'overdue'>('all');
   const [clientFilter, setClientFilter] = useState('All');
   const [sort, setSort] = useState<'date' | 'days' | 'fu'>('date');
+  const [showSettings, setShowSettings] = useState(false);
+  const [sheetUrl, setSheetUrl] = useState('');
+  const [liveData, setLiveData] = useState<IntroEmail[] | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<string>('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string>('');
+
+  useEffect(() => {
+    const url = getStorage<string>(SHEET_URL_KEY, '');
+    setSheetUrl(url);
+    const cached = getStorage<IntroEmail[] | null>(SHEET_DATA_KEY, null);
+    if (cached && cached.length > 0) setLiveData(cached);
+    setLastUpdated(getStorage<string>(SHEET_UPDATED_KEY, ''));
+  }, []);
+
+  async function refresh() {
+    if (!sheetUrl) {
+      setError('Paste a Google Sheet CSV URL in settings first.');
+      return;
+    }
+    setLoading(true);
+    setError('');
+    try {
+      const data = await fetchSheetCSV(sheetUrl);
+      if (data.length === 0) throw new Error('No rows found in sheet.');
+      setLiveData(data);
+      setStorage(SHEET_DATA_KEY, data);
+      const now = new Date().toLocaleString();
+      setLastUpdated(now);
+      setStorage(SHEET_UPDATED_KEY, now);
+    } catch (err: any) {
+      setError(err.message || 'Fetch failed. Make sure the sheet is published to web as CSV.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function saveUrl() {
+    setStorage(SHEET_URL_KEY, sheetUrl);
+    setShowSettings(false);
+  }
+
+  function clearLive() {
+    setLiveData(null);
+    setStorage(SHEET_DATA_KEY, null);
+    setLastUpdated('');
+    setStorage(SHEET_UPDATED_KEY, '');
+  }
+
+  const source = liveData || introEmails;
+  const isLive = liveData !== null;
 
   const enriched = useMemo(() => {
-    return introEmails.map((e, i) => {
+    return source.map((e, i) => {
       const days = daysBetween(e.date, REF_DATE);
       const fu1 = addBusinessDays(e.date, 3);
       const fu2 = addBusinessDays(e.date, 6);
@@ -29,17 +87,17 @@ export default function IntroEmails() {
 
       return { ...e, idx: i + 1, days, fu1, fu2, fu3, fu1Due, fu2Due, fu3Due, replied, overdueFUs, fuStatus };
     });
-  }, []);
+  }, [source]);
 
   const clients = useMemo(() => {
-    const set = new Set(introEmails.map((e) => e.co));
+    const set = new Set(source.map((e) => e.co));
     return ['All', ...Array.from(set).sort()];
-  }, []);
+  }, [source]);
 
   const totalReplied = enriched.filter((e) => e.replied).length;
   const totalNoReply = enriched.filter((e) => !e.replied).length;
   const totalOverdue = enriched.filter((e) => !e.replied && e.overdueFUs > 0).length;
-  const responseRate = Math.round((totalReplied / enriched.length) * 100);
+  const responseRate = enriched.length ? Math.round((totalReplied / enriched.length) * 100) : 0;
 
   const filtered = useMemo(() => {
     let data = enriched;
@@ -55,6 +113,72 @@ export default function IntroEmails() {
 
   return (
     <div className="space-y-4">
+      {/* Source banner */}
+      <div className={`flex items-center justify-between rounded-2xl border px-4 py-2.5 text-xs ${
+        isLive ? 'border-healthy/30 bg-healthy/5' : 'border-border bg-card'
+      }`}>
+        <div className="flex items-center gap-2">
+          <Link2 size={12} className={isLive ? 'text-healthy' : 'text-muted'} />
+          <span className={isLive ? 'text-healthy' : 'text-muted'}>
+            {isLive ? `Live from Google Sheet · Updated ${lastUpdated}` : 'Using static seed data (131 emails)'}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          {sheetUrl && (
+            <button
+              onClick={refresh}
+              disabled={loading}
+              className="flex items-center gap-1 text-muted hover:text-fg"
+            >
+              {loading ? <Loader2 size={12} className="animate-spin" /> : <RefreshCw size={12} />}
+              {loading ? 'Fetching...' : 'Refresh'}
+            </button>
+          )}
+          <button
+            onClick={() => setShowSettings(!showSettings)}
+            className="flex items-center gap-1 text-muted hover:text-fg"
+          >
+            <Settings size={12} /> Settings
+          </button>
+        </div>
+      </div>
+
+      {error && <div className="bg-risk/10 border border-risk/30 text-risk text-xs px-3 py-2 rounded-lg">{error}</div>}
+
+      {showSettings && (
+        <div className="bg-card border border-border rounded-2xl p-4 space-y-3">
+          <div>
+            <label className="text-[10px] text-muted uppercase tracking-wider">Google Sheet Published CSV URL</label>
+            <p className="text-[11px] text-muted mt-1 mb-2">
+              In Google Sheets: <b className="text-fg">File &rarr; Share &rarr; Publish to web</b>, select the tab, choose "Comma-separated values (.csv)", click <b className="text-fg">Publish</b>, then paste the URL here.
+            </p>
+            <input
+              value={sheetUrl}
+              onChange={(e) => setSheetUrl(e.target.value)}
+              placeholder="https://docs.google.com/spreadsheets/d/e/.../pub?output=csv"
+              className="w-full bg-border/50 border border-border rounded-lg px-3 py-2 text-xs text-fg font-mono focus:border-accent focus:outline-none"
+            />
+          </div>
+          <p className="text-[10px] text-muted">
+            Expected columns: A=Candidate, B=Email, C=Company, D=Role, E=Intro Date, F=Days Since, G=Replied?, ...
+          </p>
+          <div className="flex gap-2">
+            <button onClick={saveUrl} className="flex items-center gap-1 bg-accent text-white px-3 py-1.5 rounded-lg text-xs font-medium hover:bg-accent/80">
+              <Check size={12} /> Save URL
+            </button>
+            <button onClick={refresh} disabled={loading || !sheetUrl} className="flex items-center gap-1 bg-healthy/20 text-healthy px-3 py-1.5 rounded-lg text-xs font-medium hover:bg-healthy/30 disabled:opacity-50">
+              {loading ? <Loader2 size={12} className="animate-spin" /> : <RefreshCw size={12} />}
+              Fetch Now
+            </button>
+            {liveData && (
+              <button onClick={clearLive} className="text-muted hover:text-risk text-xs">
+                Clear live data (use seed)
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
       <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
         <StatCard label="Total Sent" value={enriched.length} />
         <StatCard label="Replied" value={totalReplied} color="text-healthy" />

--- a/lib/sheetFetch.ts
+++ b/lib/sheetFetch.ts
@@ -1,0 +1,81 @@
+'use client';
+
+import type { IntroEmail } from '@/data/emails';
+
+/**
+ * Fetch a published Google Sheet as CSV and parse into intro-email rows.
+ *
+ * HOW TO GET THE URL:
+ * 1. Open the Contrario Email Tracker Google Sheet
+ * 2. File -> Share -> Publish to web
+ * 3. Choose the tab, select "Comma-separated values (.csv)"
+ * 4. Click Publish, copy the URL
+ * 5. Paste it into the Intro Emails tab settings
+ *
+ * Expected columns (from the n8n workflow spec):
+ * A Candidate Name | B Candidate Email | C Company | D Role | E Intro Date
+ * F Days Since | G Replied? | H Reply Date | I Reply Snippet
+ * J FU Sent? | K FU Round | L Status | M Thread ID | N Last Updated
+ */
+
+function parseCSVLine(line: string): string[] {
+  const cells: string[] = [];
+  let cur = '';
+  let inQuote = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (inQuote) {
+      if (ch === '"' && line[i + 1] === '"') { cur += '"'; i++; }
+      else if (ch === '"') inQuote = false;
+      else cur += ch;
+    } else {
+      if (ch === ',') { cells.push(cur); cur = ''; }
+      else if (ch === '"') inQuote = true;
+      else cur += ch;
+    }
+  }
+  cells.push(cur);
+  return cells;
+}
+
+export function parseCSV(csv: string): string[][] {
+  const lines = csv.split(/\r?\n/).filter((l) => l.trim().length > 0);
+  return lines.map(parseCSVLine);
+}
+
+export async function fetchSheetCSV(url: string): Promise<IntroEmail[]> {
+  const res = await fetch(url, { cache: 'no-store' });
+  if (!res.ok) throw new Error(`Sheet fetch failed: ${res.status}`);
+  const text = await res.text();
+  const rows = parseCSV(text);
+  if (rows.length < 2) return [];
+
+  // Skip header row
+  return rows.slice(1).map((r) => {
+    const replied = (r[6] || '').trim().toUpperCase();
+    return {
+      date: normalizeDate(r[4] || ''),
+      name: (r[0] || '').trim(),
+      role: (r[3] || '').trim(),
+      co: (r[2] || '').trim(),
+      replied: replied === 'YES' || replied === 'Y' || replied === 'TRUE',
+    } as IntroEmail;
+  }).filter((e) => e.name && e.date);
+}
+
+function normalizeDate(s: string): string {
+  const trimmed = s.trim();
+  if (!trimmed) return '';
+  // Try ISO first
+  if (/^\d{4}-\d{2}-\d{2}/.test(trimmed)) return trimmed.slice(0, 10);
+  // Try M/D/YYYY or MM/DD/YYYY
+  const slash = trimmed.split('/');
+  if (slash.length === 3) {
+    const [m, d, y] = slash;
+    return `${y}-${String(m).padStart(2, '0')}-${String(d).padStart(2, '0')}`;
+  }
+  // Try "Apr 10, 2026"
+  const dt = new Date(trimmed);
+  if (!isNaN(dt.getTime())) return dt.toISOString().slice(0, 10);
+  return '';
+}


### PR DESCRIPTION
Intro Emails tab:
- Added Settings panel to configure a Google Sheet published CSV URL
- Fetches live tracker data from the sheet (parses columns from n8n spec)
- Source banner shows "Live from Google Sheet" vs "Using static seed"
- Refresh button pulls latest data; caches last pull in localStorage
- Falls back to 131 seeded emails when no URL is set
- Handles M/D/YYYY, ISO, and "Apr 10, 2026" date formats

New Daily Scan tab (9th tab):
- Paste today's inbox scan report output (from Claude Code or n8n)
- Auto-extracts stats (Replied / Pending / Needs FU) from the text
- Saves to localStorage with date + stats
- Scan history with expand/collapse, copy-to-clipboard, delete
- Top stat cards show latest scan's numbers at a glance

Library additions:
- lib/sheetFetch.ts: robust CSV parser + Google Sheet fetch helper
- Handles quoted cells, escaped quotes, multiple date formats

How to wire up (for Lucia):
1. Publish the n8n tracker sheet: File > Share > Publish to web > CSV
2. Copy URL, paste into Intro Emails > Settings, Save, Fetch Now
3. Dashboard now mirrors live tracker data

Build verified — 9 tabs, single-page app, all static.

https://claude.ai/code/session_017HSEj5jajy6MztwFoXXSMq