### PR TITLE
feat: Contrario AI Ops Agent — morning brief, follow-up drafting, JD creation, AI chat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+ANTHROPIC_API_KEY=sk-ant-...

--- a/app/agent/page.tsx
+++ b/app/agent/page.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { supabase, isSupabaseConfigured } from '@/lib/supabase';
+import { daysSince } from '@/lib/utils';
+import PageHeader from '@/components/ui/PageHeader';
+import MorningBrief from '@/components/agent/MorningBrief';
+import DailyChecklist from '@/components/agent/DailyChecklist';
+import PendingApprovals from '@/components/agent/PendingApprovals';
+import AIChatPanel from '@/components/agent/AIChatPanel';
+import JDCreator from '@/components/agent/JDCreator';
+import { Bot, MessageSquare, Layers, CheckSquare, FileText } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+type Tab = 'overview' | 'jd';
+
+export default function AgentPage() {
+  const [chatOpen, setChatOpen] = useState(true);
+  const [tab, setTab] = useState<Tab>('overview');
+  const enabled = isSupabaseConfigured();
+
+  const { data: context } = useQuery({
+    queryKey: ['agent-context'],
+    enabled,
+    queryFn: async () => {
+      const now = new Date().toISOString();
+      const [{ data: followups }, { data: tasks }, { count: roles }, { count: pending }] = await Promise.all([
+        supabase
+          .from('candidates')
+          .select('name, role:roles(title, client:clients(name)), intro_sent_at, followup_round')
+          .eq('response_status', 'pending')
+          .lte('next_followup_due', now)
+          .eq('archived', false)
+          .limit(10),
+        supabase
+          .from('tasks')
+          .select('title, priority, client:clients(name)')
+          .neq('status', 'done')
+          .order('priority', { ascending: true })
+          .limit(5),
+        supabase.from('roles').select('*', { count: 'exact', head: true }).in('status', ['live', 'outreach_ready']).eq('archived', false),
+        supabase.from('candidates').select('*', { count: 'exact', head: true }).eq('response_status', 'pending').eq('archived', false),
+      ]);
+
+      const lines: string[] = [
+        `Active roles: ${roles ?? 0}`,
+        `Candidates pending response: ${pending ?? 0}`,
+        `Follow-ups due today: ${followups?.length ?? 0}`,
+      ];
+      if (followups?.length) {
+        lines.push('Overdue follow-ups: ' + followups.map((f: any) => `${f.name} (${f.role?.title} at ${f.role?.client?.name}, ${daysSince(f.intro_sent_at)}d, R${f.followup_round + 1})`).join('; '));
+      }
+      if (tasks?.length) {
+        lines.push('Open tasks: ' + tasks.map((t: any) => `${t.title} [${t.priority}]${t.client?.name ? ` — ${t.client.name}` : ''}`).join('; '));
+      }
+      return lines.join('\n');
+    },
+  });
+
+  return (
+    <div className="flex gap-0 -mx-6 lg:-mx-10 min-h-[calc(100vh-120px)]">
+      {/* Main column */}
+      <div className="flex-1 min-w-0 px-6 lg:px-10 py-0 space-y-6 overflow-y-auto">
+        <PageHeader
+          title="AI Ops Agent"
+          description="Morning brief · Follow-up intelligence · JD creation"
+          action={
+            <div className="flex items-center gap-2">
+              <button
+                onClick={() => setChatOpen((o) => !o)}
+                className={cn(
+                  'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-all border',
+                  chatOpen
+                    ? 'bg-gold/15 border-gold/30 text-gold'
+                    : 'bg-surface border-border text-muted hover:text-fg'
+                )}
+              >
+                <Bot size={13} /> AI Co-pilot
+              </button>
+            </div>
+          }
+        />
+
+        {/* Tab nav */}
+        <div className="flex gap-1 bg-elevated/50 rounded-xl p-1 w-fit">
+          {([
+            ['overview', 'Overview', Layers],
+            ['jd', 'JD Creator', FileText],
+          ] as const).map(([val, label, Icon]) => (
+            <button
+              key={val}
+              onClick={() => setTab(val)}
+              className={cn(
+                'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-all',
+                tab === val ? 'bg-surface text-fg shadow-sm' : 'text-muted hover:text-fg'
+              )}
+            >
+              <Icon size={12} /> {label}
+            </button>
+          ))}
+        </div>
+
+        {tab === 'overview' && (
+          <div className="space-y-6">
+            <MorningBrief />
+            <DailyChecklist />
+            <PendingApprovals />
+          </div>
+        )}
+
+        {tab === 'jd' && <JDCreator />}
+      </div>
+
+      {/* Chat sidebar */}
+      {chatOpen && (
+        <div className="w-[340px] shrink-0 border-l border-border bg-surface flex flex-col sticky top-0 h-[calc(100vh-64px)]">
+          <AIChatPanel context={context ?? undefined} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/api/ai/chat/route.ts
+++ b/app/api/ai/chat/route.ts
@@ -1,0 +1,58 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { NextRequest } from 'next/server';
+
+const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+export async function POST(req: NextRequest) {
+  const { messages, context } = await req.json();
+
+  const systemPrompt = `You are Lucía's AI operations co-pilot at Contrario — a managed recruiting marketplace.
+
+About Contrario:
+- Managed recruiting marketplace with Lucía as Ops Lead
+- 110+ active roles across 39 clients
+- 236+ candidates pending client approval
+- Team of independent recruiters on the platform
+
+Key rules you always follow:
+- All outreach is in Contrario voice: direct, no fluff, under 60 words for follow-ups
+- Never include unverified traction claims in JDs (e.g., ARR figures without a source)
+- Equity is separate from base salary — never list equity in the salary field
+- OTE is separate from base — always show both
+- Follow-up cadence: SEQ1 (intro) → SEQ2 (day 5–7, same thread) → SEQ3 (day 7–10, new thread)
+- Candidate submissions require a venture-backed (≥$10M) signal called out at top of summary
+- YOE cap: 8 years max on relevant experience unless role specifies otherwise
+
+Current ops context:
+${context || 'No additional context provided.'}
+
+Be concise and actionable. When drafting emails or messages, follow Contrario voice exactly.`;
+
+  const anthropicMessages = messages.map((m: { role: string; content: string }) => ({
+    role: m.role as 'user' | 'assistant',
+    content: m.content,
+  }));
+
+  const stream = await client.messages.stream({
+    model: 'claude-sonnet-4-20250514',
+    max_tokens: 1024,
+    system: systemPrompt,
+    messages: anthropicMessages,
+  });
+
+  const encoder = new TextEncoder();
+  const readable = new ReadableStream({
+    async start(controller) {
+      for await (const chunk of stream) {
+        if (chunk.type === 'content_block_delta' && chunk.delta.type === 'text_delta') {
+          controller.enqueue(encoder.encode(chunk.delta.text));
+        }
+      }
+      controller.close();
+    },
+  });
+
+  return new Response(readable, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8', 'Cache-Control': 'no-cache' },
+  });
+}

--- a/app/api/ai/draft-followup/route.ts
+++ b/app/api/ai/draft-followup/route.ts
@@ -1,0 +1,57 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { NextRequest } from 'next/server';
+
+const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+export async function POST(req: NextRequest) {
+  const { candidate, role, client: clientName, round, daysSince } = await req.json();
+
+  const systemPrompt = `You are a senior recruiting operations specialist at Contrario writing follow-up emails.
+
+Contrario voice rules:
+- Direct, no fluff, no filler phrases like "hope you're well" or "just checking in"
+- Under 60 words
+- No bullets
+- No sign-off beyond "Best, The Contrario Team"
+- Never re-pitch the role — assume they already know it
+- Goal: get the candidate to book or respond
+- Subject line: leave blank (same thread, no new subject)
+
+Round context:
+- SEQ 1: intro (already sent)
+- SEQ 2 (day 5–7, same thread): light nudge, mention one specific thing about the role
+- SEQ 3 (day 7–10, new thread): final attempt, create mild urgency around timeline
+
+Output format — respond with ONLY a JSON object:
+{"subject": "", "body": "...email body here..."}`;
+
+  const userPrompt = `Write a follow-up email for:
+Candidate: ${candidate}
+Role: ${role}
+Company: ${clientName}
+Days since intro: ${daysSince}
+Follow-up round: ${round} (so this is SEQ ${round + 1})`;
+
+  const stream = await client.messages.stream({
+    model: 'claude-sonnet-4-20250514',
+    max_tokens: 300,
+    system: systemPrompt,
+    messages: [{ role: 'user', content: userPrompt }],
+  });
+
+  const encoder = new TextEncoder();
+  const readable = new ReadableStream({
+    async start(controller) {
+      for await (const chunk of stream) {
+        if (chunk.type === 'content_block_delta' && chunk.delta.type === 'text_delta') {
+          controller.enqueue(encoder.encode(chunk.delta.text));
+        }
+      }
+      controller.close();
+    },
+  });
+
+  return new Response(readable, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8', 'Cache-Control': 'no-cache' },
+  });
+}

--- a/app/api/ai/jd-create/route.ts
+++ b/app/api/ai/jd-create/route.ts
@@ -1,0 +1,72 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { NextRequest } from 'next/server';
+
+const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+export async function POST(req: NextRequest) {
+  const { company, role, compensation, equity, ote, requirements, interviewStages, notes } = await req.json();
+
+  const systemPrompt = `You are a senior recruiting operations specialist at Contrario producing complete JD packages.
+
+Rules:
+- Never include unverified traction claims (e.g. ARR figures without a source)
+- Equity is always separate from base salary — never conflate them
+- OTE is always separate from base — show both explicitly
+- YOE cap: 8 years max unless the role specifies otherwise
+- Venture-backed signal (≥$10M raised) must be called out if applicable
+- Lead with traction and momentum, not generic company descriptions
+- Role bullets are outcome-framed ("You will own X" not "Responsible for X")
+
+Output format — produce the complete package in these labeled sections:
+
+## JD BODY
+[2–3 sentence company description leading with traction. About the Role paragraph. What You'll Own (4–6 outcome-framed bullets). Requirements chips: Must-have and Nice-to-have. Who Will Thrive Here (2–3 behavioral signals). Interview Process stages.]
+
+## SEQ 1 — COLD OUTREACH
+[Under 80 words. Hook on why this role/company is compelling. No re-pitch after this.]
+
+## SEQ 2 — FOLLOW-UP
+[Under 60 words. Same thread. Nudge. Reference one specific thing about the role. No re-pitch.]
+
+## SEQ 3 — FINAL NUDGE
+[Under 60 words. New thread. Mild timeline urgency. Last attempt tone.]
+
+## INTRO EMAIL
+[Personalized intro connecting candidate to role. Under 100 words.]
+
+Pre-publish flags to check: equity vs salary separation, OTE shown separately, no unverified ARR claims.`;
+
+  const userPrompt = `Create a full JD package for:
+
+Company: ${company}
+Role: ${role}
+Base Compensation: ${compensation || 'Not specified'}
+Equity: ${equity || 'Not specified'}
+OTE: ${ote || 'Not specified'}
+Key Requirements: ${requirements || 'Not specified'}
+Interview Stages: ${interviewStages || 'Not specified'}
+Additional Notes: ${notes || 'None'}`;
+
+  const stream = await client.messages.stream({
+    model: 'claude-sonnet-4-20250514',
+    max_tokens: 2000,
+    system: systemPrompt,
+    messages: [{ role: 'user', content: userPrompt }],
+  });
+
+  const encoder = new TextEncoder();
+  const readable = new ReadableStream({
+    async start(controller) {
+      for await (const chunk of stream) {
+        if (chunk.type === 'content_block_delta' && chunk.delta.type === 'text_delta') {
+          controller.enqueue(encoder.encode(chunk.delta.text));
+        }
+      }
+      controller.close();
+    },
+  });
+
+  return new Response(readable, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8', 'Cache-Control': 'no-cache' },
+  });
+}

--- a/app/api/ai/morning-brief/route.ts
+++ b/app/api/ai/morning-brief/route.ts
@@ -1,0 +1,58 @@
+import Anthropic from '@anthropic-ai/sdk';
+import { NextRequest } from 'next/server';
+
+const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const { followupsDue = [], openTasks = [], activeRoles = 0, pendingCandidates = 0 } = body;
+
+  const contextSummary = `
+CONTRARIO OPS CONTEXT:
+- ${activeRoles} active roles across clients
+- ${pendingCandidates} candidates pending response
+- ${followupsDue.length} follow-ups due today
+- ${openTasks.length} open tasks
+
+FOLLOW-UPS DUE TODAY:
+${followupsDue.slice(0, 8).map((f: any) => `• ${f.name} → ${f.role?.title || 'Unknown role'} at ${f.role?.client?.name || 'Unknown client'} (${f.days}d since intro, Round ${f.followup_round + 1})`).join('\n') || 'None'}
+
+OPEN TASKS:
+${openTasks.slice(0, 5).map((t: any) => `• [${t.priority?.toUpperCase()}] ${t.title}${t.client?.name ? ` — ${t.client.name}` : ''}`).join('\n') || 'None'}
+`.trim();
+
+  const systemPrompt = `You are Lucía's AI operations co-pilot at Contrario — a managed recruiting marketplace.
+Contrario manages 110+ active roles across 39 clients, with Lucía as Ops Lead managing the full pipeline.
+
+Write a sharp morning brief for Lucía. No fluff. No "Good morning!" opener. Start with the most critical item immediately.
+
+Structure:
+**Priority Queue** — ranked list of the 3 most urgent actions (follow-ups overdue, tasks due, blockers)
+**Follow-Up Alerts** — specific candidates to chase today with context on why they're urgent
+**Today's Focus** — one sentence on what matters most today
+
+Keep it under 200 words. Be specific. Use the data provided.`;
+
+  const stream = await client.messages.stream({
+    model: 'claude-sonnet-4-20250514',
+    max_tokens: 600,
+    system: systemPrompt,
+    messages: [{ role: 'user', content: `Generate my morning brief.\n\n${contextSummary}` }],
+  });
+
+  const encoder = new TextEncoder();
+  const readable = new ReadableStream({
+    async start(controller) {
+      for await (const chunk of stream) {
+        if (chunk.type === 'content_block_delta' && chunk.delta.type === 'text_delta') {
+          controller.enqueue(encoder.encode(chunk.delta.text));
+        }
+      }
+      controller.close();
+    },
+  });
+
+  return new Response(readable, {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8', 'Cache-Control': 'no-cache' },
+  });
+}

--- a/app/emails/page.tsx
+++ b/app/emails/page.tsx
@@ -8,7 +8,7 @@ import StatCard from '@/components/ui/StatCard';
 import { Badge, Dot } from '@/components/ui/Badge';
 import EmptyState from '@/components/ui/EmptyState';
 import SupabaseGate from '@/components/ui/SupabaseGate';
-import { Search, Mail, Plus, X, Save } from 'lucide-react';
+import { Search, Mail, Plus, X, Save, Sparkles, Copy, Check, Loader2 } from 'lucide-react';
 import type { Candidate, ResponseStatus } from '@/lib/types';
 import { formatDate, daysSince, nextFollowupDue } from '@/lib/utils';
 
@@ -29,6 +29,41 @@ export default function EmailsPage() {
   const [filter, setFilter] = useState<'all' | 'needs_fu' | 'replied_week' | 'no_response'>('all');
   const [statusFilter, setStatusFilter] = useState<ResponseStatus | 'All'>('All');
   const [showNew, setShowNew] = useState(false);
+  const [draftOpen, setDraftOpen] = useState<string | null>(null);
+  const [draftText, setDraftText] = useState<Record<string, string>>({});
+  const [draftLoading, setDraftLoading] = useState<Record<string, boolean>>({});
+
+  async function generateDraft(c: Candidate) {
+    setDraftOpen(c.id);
+    if (draftText[c.id]) return;
+    setDraftLoading((p) => ({ ...p, [c.id]: true }));
+    setDraftText((p) => ({ ...p, [c.id]: '' }));
+    try {
+      const res = await fetch('/api/ai/draft-followup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          candidate: c.name,
+          role: c.role?.title ?? 'the role',
+          client: c.role?.client?.name ?? 'the company',
+          round: c.followup_round,
+          daysSince: daysSince(c.intro_sent_at),
+        }),
+      });
+      if (!res.ok) throw new Error('Failed');
+      const reader = res.body!.getReader();
+      const decoder = new TextDecoder();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        setDraftText((p) => ({ ...p, [c.id]: (p[c.id] ?? '') + decoder.decode(value) }));
+      }
+    } catch {
+      setDraftText((p) => ({ ...p, [c.id]: 'Error generating draft. Check ANTHROPIC_API_KEY.' }));
+    } finally {
+      setDraftLoading((p) => ({ ...p, [c.id]: false }));
+    }
+  }
 
   const { data: candidates = [] } = useQuery({
     queryKey: ['candidates'],
@@ -176,6 +211,7 @@ export default function EmailsPage() {
                 </thead>
                 <tbody>
                   {filtered.map((c) => (
+                    <>
                     <tr key={c.id} className="border-b border-border/50 hover:bg-elevated/30">
                       <td className="px-4 py-3">
                         <div className="font-medium">{c.name}</div>
@@ -208,6 +244,12 @@ export default function EmailsPage() {
                         <div className="flex justify-end gap-1">
                           {c.response_status === 'pending' && (
                             <>
+                              <button
+                                onClick={() => generateDraft(c)}
+                                className="text-xs px-2 py-1 rounded bg-elevated border border-border text-muted hover:text-fg hover:border-gold/40 inline-flex items-center gap-1"
+                              >
+                                <Sparkles size={10} /> Draft
+                              </button>
                               <button onClick={() => markReplied(c.id)} className="text-xs px-2 py-1 rounded bg-success/15 text-success hover:bg-success/25">Replied</button>
                               {c.followup_round < 3 && (
                                 <button onClick={() => advanceFollowup(c)} className="text-xs px-2 py-1 rounded bg-gold/15 text-gold hover:bg-gold/25">+FU</button>
@@ -217,6 +259,19 @@ export default function EmailsPage() {
                         </div>
                       </td>
                     </tr>
+                    {draftOpen === c.id && (
+                      <tr key={`${c.id}-draft`} className="bg-elevated/20">
+                        <td colSpan={8} className="px-4 py-3">
+                          <InlineDraft
+                            loading={!!draftLoading[c.id]}
+                            text={draftText[c.id] ?? ''}
+                            onClose={() => setDraftOpen(null)}
+                            onRefresh={() => { setDraftText((p) => ({ ...p, [c.id]: '' })); generateDraft(c); }}
+                          />
+                        </td>
+                      </tr>
+                    )}
+                    </>
                   ))}
                 </tbody>
               </table>
@@ -227,6 +282,54 @@ export default function EmailsPage() {
       </SupabaseGate>
 
       {showNew && <NewCandidateModal roles={roles} onClose={() => setShowNew(false)} onCreated={() => { qc.invalidateQueries({ queryKey: ['candidates'] }); setShowNew(false); }} />}
+    </div>
+  );
+}
+
+function InlineDraft({ loading, text, onClose, onRefresh }: { loading: boolean; text: string; onClose: () => void; onRefresh: () => void }) {
+  const [copied, setCopied] = useState(false);
+
+  let body = text;
+  try {
+    const parsed = JSON.parse(text);
+    body = parsed.body ?? text;
+  } catch {}
+
+  function copy() {
+    navigator.clipboard.writeText(body);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <div className="rounded-xl border border-gold/20 bg-surface p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 text-xs text-gold font-medium">
+          <Sparkles size={12} />
+          AI Draft — Contrario Voice
+          {loading && <Loader2 size={11} className="animate-spin text-muted" />}
+        </div>
+        <div className="flex items-center gap-1">
+          <button onClick={onRefresh} className="text-xs px-2 py-1 rounded border border-border text-muted hover:text-fg">Regenerate</button>
+          <button onClick={onClose} className="p-1 text-muted hover:text-fg"><X size={13} /></button>
+        </div>
+      </div>
+      {body && (
+        <>
+          <div className="text-sm text-fg whitespace-pre-wrap leading-relaxed font-mono bg-elevated/50 rounded-lg px-3 py-2.5 border border-border/50">
+            {body}
+          </div>
+          <div className="flex justify-end">
+            <button
+              onClick={copy}
+              className="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg bg-gold/15 text-gold hover:bg-gold/25 transition-colors"
+            >
+              {copied ? <Check size={11} /> : <Copy size={11} />}
+              {copied ? 'Copied!' : 'Copy to clipboard'}
+            </button>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -63,4 +63,7 @@
   .dot {
     @apply inline-block w-1.5 h-1.5 rounded-full;
   }
+  .input {
+    @apply w-full bg-elevated border border-border rounded-lg px-3 py-2 text-sm focus:border-gold/50 focus:outline-none transition-colors;
+  }
 }

--- a/components/agent/AIChatPanel.tsx
+++ b/components/agent/AIChatPanel.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { Send, Loader2, Bot, User, X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+const QUICK_ACTIONS = [
+  { label: 'Draft today\'s nudges', prompt: 'List the candidates who need a follow-up today and draft a nudge for each in Contrario voice.' },
+  { label: 'Write a Slack reply', prompt: 'Help me write a reply to a Slack message in Contrario voice. What context should I give you?' },
+  { label: 'Summarize attention items', prompt: 'Based on the current ops context, what needs my attention most urgently right now?' },
+  { label: 'Create a JD package', prompt: 'I need to create a JD package. Ask me for the role details.' },
+];
+
+export default function AIChatPanel({ context }: { context?: string }) {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  async function send(userContent: string) {
+    if (!userContent.trim() || loading) return;
+    const userMsg: Message = { role: 'user', content: userContent.trim() };
+    const newMessages = [...messages, userMsg];
+    setMessages(newMessages);
+    setInput('');
+    setLoading(true);
+
+    const assistantMsg: Message = { role: 'assistant', content: '' };
+    setMessages([...newMessages, assistantMsg]);
+
+    try {
+      const res = await fetch('/api/ai/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages: newMessages, context }),
+      });
+      if (!res.ok) throw new Error('Request failed');
+      const reader = res.body!.getReader();
+      const decoder = new TextDecoder();
+      let full = '';
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        full += decoder.decode(value);
+        setMessages([...newMessages, { role: 'assistant', content: full }]);
+        bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+      }
+    } catch {
+      setMessages([...newMessages, { role: 'assistant', content: 'Something went wrong. Check ANTHROPIC_API_KEY.' }]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleKey(e: React.KeyboardEvent) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      send(input);
+    }
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="px-4 py-3 border-b border-border">
+        <div className="flex items-center gap-2">
+          <Bot size={14} className="text-gold" />
+          <span className="font-display font-semibold text-sm">AI Co-pilot</span>
+        </div>
+        <p className="text-xs text-muted mt-0.5">Contrario context loaded</p>
+      </div>
+
+      {messages.length === 0 && (
+        <div className="p-4 space-y-2">
+          <p className="text-xs text-muted mb-3">Quick actions:</p>
+          {QUICK_ACTIONS.map((a) => (
+            <button
+              key={a.label}
+              onClick={() => send(a.prompt)}
+              className="w-full text-left text-xs px-3 py-2 rounded-lg border border-border hover:border-gold/40 hover:bg-elevated/50 transition-colors text-muted hover:text-fg"
+            >
+              {a.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div className="flex-1 overflow-y-auto p-4 space-y-4 min-h-0">
+        {messages.map((m, i) => (
+          <div key={i} className={cn('flex gap-2', m.role === 'user' ? 'justify-end' : 'justify-start')}>
+            {m.role === 'assistant' && (
+              <div className="w-6 h-6 rounded-full bg-gold/15 flex items-center justify-center shrink-0 mt-0.5">
+                <Bot size={11} className="text-gold" />
+              </div>
+            )}
+            <div
+              className={cn(
+                'max-w-[85%] text-sm rounded-2xl px-3 py-2 whitespace-pre-wrap',
+                m.role === 'user'
+                  ? 'bg-gold/15 text-fg rounded-tr-sm'
+                  : 'bg-elevated text-fg rounded-tl-sm'
+              )}
+            >
+              {m.content || (loading && i === messages.length - 1 ? <Loader2 size={12} className="animate-spin text-muted" /> : '')}
+            </div>
+            {m.role === 'user' && (
+              <div className="w-6 h-6 rounded-full bg-elevated flex items-center justify-center shrink-0 mt-0.5">
+                <User size={11} className="text-muted" />
+              </div>
+            )}
+          </div>
+        ))}
+        <div ref={bottomRef} />
+      </div>
+
+      <div className="p-4 border-t border-border">
+        <div className="flex gap-2 items-end">
+          <textarea
+            ref={inputRef}
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKey}
+            placeholder="Ask anything…"
+            rows={1}
+            className="flex-1 bg-elevated border border-border rounded-xl px-3 py-2 text-sm resize-none focus:border-gold/50 focus:outline-none min-h-[38px] max-h-[120px]"
+            style={{ height: 'auto' }}
+          />
+          <button
+            onClick={() => send(input)}
+            disabled={loading || !input.trim()}
+            className="shrink-0 w-9 h-9 rounded-xl bg-gold text-black flex items-center justify-center transition-all hover:opacity-90 disabled:opacity-40"
+          >
+            {loading ? <Loader2 size={14} className="animate-spin" /> : <Send size={14} />}
+          </button>
+        </div>
+        <p className="text-[10px] text-muted mt-1.5 text-center">Enter to send · Shift+Enter for newline</p>
+      </div>
+    </div>
+  );
+}

--- a/components/agent/DailyChecklist.tsx
+++ b/components/agent/DailyChecklist.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Check, Circle, ArrowRight } from 'lucide-react';
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+
+const TASKS = [
+  { id: 'inbox-scan', label: 'Inbox scan', description: 'Check who replied, scheduled, or withdrew', href: '/emails' },
+  { id: 'followups', label: 'Draft follow-ups', description: 'Threads 3+ days old with no response', href: '/emails?filter=needs_fu' },
+  { id: 'slack-sweep', label: 'Recruiter Slack sweep', description: 'Answer questions from recruiters', href: '/tags' },
+  { id: 'client-channels', label: 'Client channels review', description: 'Pending approvals, unread messages', href: '/' },
+  { id: 'client-dashboard', label: 'Client dashboard check', description: 'Pipeline + pending candidates', href: '/clients' },
+  { id: 'jd-creation', label: 'JD creation (if requested)', description: 'Draft any new JDs requested today', href: '/agent?tab=jd' },
+  { id: 'respond-tags', label: 'Respond to all @tags', description: 'Clear all @lucia mentions', href: '/tags' },
+];
+
+function getTodayKey() {
+  return `checklist-${new Date().toISOString().split('T')[0]}`;
+}
+
+export default function DailyChecklist() {
+  const [checked, setChecked] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(getTodayKey());
+      if (saved) setChecked(new Set(JSON.parse(saved)));
+    } catch {}
+  }, []);
+
+  function toggle(id: string) {
+    setChecked((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      try { localStorage.setItem(getTodayKey(), JSON.stringify([...next])); } catch {}
+      return next;
+    });
+  }
+
+  const done = checked.size;
+  const total = TASKS.length;
+  const pct = Math.round((done / total) * 100);
+
+  return (
+    <div className="card p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="font-display font-bold text-base">Daily Ops Checklist</h2>
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-xs text-muted">{done}/{total}</span>
+          <div className="w-20 h-1.5 bg-elevated rounded-full overflow-hidden">
+            <div
+              className="h-full bg-gold rounded-full transition-all"
+              style={{ width: `${pct}%` }}
+            />
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-1">
+        {TASKS.map((task) => {
+          const isDone = checked.has(task.id);
+          return (
+            <div
+              key={task.id}
+              className={cn(
+                'flex items-center gap-3 px-3 py-2.5 rounded-lg transition-colors group',
+                isDone ? 'opacity-50' : 'hover:bg-elevated/50'
+              )}
+            >
+              <button
+                onClick={() => toggle(task.id)}
+                className={cn(
+                  'shrink-0 w-4 h-4 rounded border transition-all flex items-center justify-center',
+                  isDone
+                    ? 'bg-gold border-gold text-black'
+                    : 'border-border hover:border-gold/60'
+                )}
+              >
+                {isDone && <Check size={10} strokeWidth={3} />}
+              </button>
+              <div className="flex-1 min-w-0">
+                <p className={cn('text-sm font-medium', isDone && 'line-through')}>{task.label}</p>
+                <p className="text-xs text-muted truncate">{task.description}</p>
+              </div>
+              <Link
+                href={task.href}
+                className="shrink-0 opacity-0 group-hover:opacity-100 text-muted hover:text-fg transition-all"
+              >
+                <ArrowRight size={13} />
+              </Link>
+            </div>
+          );
+        })}
+      </div>
+
+      {done === total && (
+        <div className="mt-4 px-3 py-2 rounded-lg bg-success/10 border border-success/20 text-success text-xs font-medium text-center">
+          All done — Lucía, you ran the ops today.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/agent/JDCreator.tsx
+++ b/components/agent/JDCreator.tsx
@@ -1,0 +1,251 @@
+'use client';
+
+import { useState } from 'react';
+import { Loader2, Copy, Check, ChevronDown, ChevronRight, Sparkles } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface FormState {
+  company: string;
+  role: string;
+  compensation: string;
+  equity: string;
+  ote: string;
+  requirements: string;
+  interviewStages: string;
+  notes: string;
+}
+
+const EMPTY: FormState = {
+  company: '',
+  role: '',
+  compensation: '',
+  equity: '',
+  ote: '',
+  requirements: '',
+  interviewStages: '',
+  notes: '',
+};
+
+const SECTIONS = ['JD BODY', 'SEQ 1 — COLD OUTREACH', 'SEQ 2 — FOLLOW-UP', 'SEQ 3 — FINAL NUDGE', 'INTRO EMAIL'];
+
+function parseOutput(raw: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const section of SECTIONS) {
+    const re = new RegExp(`## ${section}\\s*\\n([\\s\\S]*?)(?=## [A-Z]|$)`, 'i');
+    const m = raw.match(re);
+    if (m) result[section] = m[1].trim();
+  }
+  if (!Object.keys(result).length) result['Full Output'] = raw;
+  return result;
+}
+
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  function copy() {
+    navigator.clipboard.writeText(text);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+  return (
+    <button
+      onClick={copy}
+      className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded border border-border hover:border-gold/40 text-muted hover:text-fg transition-all"
+    >
+      {copied ? <Check size={11} className="text-success" /> : <Copy size={11} />}
+      {copied ? 'Copied' : 'Copy'}
+    </button>
+  );
+}
+
+function Section({ title, content }: { title: string; content: string }) {
+  const [open, setOpen] = useState(true);
+  return (
+    <div className="border border-border rounded-xl overflow-hidden">
+      <button
+        onClick={() => setOpen((o) => !o)}
+        className="w-full flex items-center justify-between px-4 py-3 bg-elevated/30 hover:bg-elevated/50 transition-colors"
+      >
+        <span className="font-mono text-xs font-medium uppercase tracking-wider text-muted">{title}</span>
+        <div className="flex items-center gap-2">
+          {open && <CopyButton text={content} />}
+          {open ? <ChevronDown size={13} className="text-muted" /> : <ChevronRight size={13} className="text-muted" />}
+        </div>
+      </button>
+      {open && (
+        <div className="p-4">
+          <pre className="text-sm text-fg whitespace-pre-wrap font-sans leading-relaxed">{content}</pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function JDCreator() {
+  const [form, setForm] = useState<FormState>(EMPTY);
+  const [raw, setRaw] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  function set(k: keyof FormState, v: string) {
+    setForm((prev) => ({ ...prev, [k]: v }));
+  }
+
+  async function generate(e: React.FormEvent) {
+    e.preventDefault();
+    if (!form.company.trim() || !form.role.trim()) return;
+    setRaw('');
+    setLoading(true);
+    try {
+      const res = await fetch('/api/ai/jd-create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(form),
+      });
+      if (!res.ok) throw new Error('Failed');
+      const reader = res.body!.getReader();
+      const decoder = new TextDecoder();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        setRaw((prev) => prev + decoder.decode(value));
+      }
+    } catch {
+      setRaw('Error generating JD. Check ANTHROPIC_API_KEY.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const parsed = raw ? parseOutput(raw) : null;
+
+  return (
+    <div className="space-y-6">
+      <div className="card p-6">
+        <div className="flex items-center gap-2 mb-5">
+          <Sparkles size={15} className="text-gold" />
+          <h2 className="font-display font-bold text-base">JD Quick-Create</h2>
+        </div>
+
+        <form onSubmit={generate} className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <Field label="Company *">
+              <input
+                required
+                value={form.company}
+                onChange={(e) => set('company', e.target.value)}
+                placeholder="e.g. Acme Corp"
+                className="input"
+              />
+            </Field>
+            <Field label="Role Title *">
+              <input
+                required
+                value={form.role}
+                onChange={(e) => set('role', e.target.value)}
+                placeholder="e.g. Senior Software Engineer"
+                className="input"
+              />
+            </Field>
+            <Field label="Base Compensation">
+              <input
+                value={form.compensation}
+                onChange={(e) => set('compensation', e.target.value)}
+                placeholder="e.g. $180k–$220k base"
+                className="input"
+              />
+            </Field>
+            <Field label="Equity">
+              <input
+                value={form.equity}
+                onChange={(e) => set('equity', e.target.value)}
+                placeholder="e.g. 0.10%–0.25%"
+                className="input"
+              />
+            </Field>
+            <Field label="OTE (if applicable)">
+              <input
+                value={form.ote}
+                onChange={(e) => set('ote', e.target.value)}
+                placeholder="e.g. $260k–$300k OTE"
+                className="input"
+              />
+            </Field>
+          </div>
+
+          <Field label="Key Requirements">
+            <textarea
+              value={form.requirements}
+              onChange={(e) => set('requirements', e.target.value)}
+              placeholder="e.g. 5+ years backend, TypeScript, distributed systems experience..."
+              rows={3}
+              className="input resize-none"
+            />
+          </Field>
+
+          <Field label="Interview Stages">
+            <textarea
+              value={form.interviewStages}
+              onChange={(e) => set('interviewStages', e.target.value)}
+              placeholder="e.g. Intro call (30m) → Technical screen (60m) → System design (90m) → Offer"
+              rows={2}
+              className="input resize-none"
+            />
+          </Field>
+
+          <Field label="Additional Notes">
+            <textarea
+              value={form.notes}
+              onChange={(e) => set('notes', e.target.value)}
+              placeholder="Venture-backed info, traction signals, hiring urgency, any context..."
+              rows={2}
+              className="input resize-none"
+            />
+          </Field>
+
+          <button
+            type="submit"
+            disabled={loading || !form.company.trim() || !form.role.trim()}
+            className="btn-primary inline-flex items-center gap-2 disabled:opacity-40"
+          >
+            {loading ? <Loader2 size={14} className="animate-spin" /> : <Sparkles size={14} />}
+            {loading ? 'Generating…' : 'Generate JD Package'}
+          </button>
+        </form>
+      </div>
+
+      {loading && !raw && (
+        <div className="card p-8 text-center">
+          <Loader2 size={20} className="animate-spin text-gold mx-auto mb-2" />
+          <p className="text-sm text-muted">Drafting your JD package…</p>
+        </div>
+      )}
+
+      {parsed && (
+        <div className="space-y-3">
+          {Object.entries(parsed).map(([title, content]) => (
+            <Section key={title} title={title} content={content} />
+          ))}
+        </div>
+      )}
+
+      {loading && raw && (
+        <div className="space-y-3">
+          {Object.entries(parseOutput(raw)).map(([title, content]) => (
+            <Section key={title} title={title} content={content} />
+          ))}
+          <div className="flex items-center gap-2 text-xs text-muted px-1">
+            <Loader2 size={11} className="animate-spin" /> Generating…
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <label className="block text-xs text-muted uppercase tracking-wider mb-1.5">{label}</label>
+      {children}
+    </div>
+  );
+}

--- a/components/agent/MorningBrief.tsx
+++ b/components/agent/MorningBrief.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { supabase, isSupabaseConfigured } from '@/lib/supabase';
+import { daysSince } from '@/lib/utils';
+import { Sparkles, RefreshCw, Loader2 } from 'lucide-react';
+
+export default function MorningBrief() {
+  const [brief, setBrief] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [ran, setRan] = useState(false);
+  const enabled = isSupabaseConfigured();
+
+  const { data: followupsDue = [] } = useQuery({
+    queryKey: ['morning-followups'],
+    enabled,
+    queryFn: async () => {
+      const now = new Date().toISOString();
+      const { data } = await supabase
+        .from('candidates')
+        .select('*, role:roles(title, client:clients(name))')
+        .eq('response_status', 'pending')
+        .lte('next_followup_due', now)
+        .eq('archived', false)
+        .limit(10);
+      return (data || []).map((c: any) => ({ ...c, days: daysSince(c.intro_sent_at) }));
+    },
+  });
+
+  const { data: openTasks = [] } = useQuery({
+    queryKey: ['morning-tasks'],
+    enabled,
+    queryFn: async () => {
+      const { data } = await supabase
+        .from('tasks')
+        .select('*, client:clients(name)')
+        .neq('status', 'done')
+        .order('priority', { ascending: true })
+        .limit(8);
+      return data || [];
+    },
+  });
+
+  const { data: stats } = useQuery({
+    queryKey: ['morning-stats'],
+    enabled,
+    queryFn: async () => {
+      const [{ count: roles }, { count: pending }] = await Promise.all([
+        supabase.from('roles').select('*', { count: 'exact', head: true }).in('status', ['live', 'outreach_ready']).eq('archived', false),
+        supabase.from('candidates').select('*', { count: 'exact', head: true }).eq('response_status', 'pending').eq('archived', false),
+      ]);
+      return { activeRoles: roles || 0, pendingCandidates: pending || 0 };
+    },
+  });
+
+  async function runBrief() {
+    setLoading(true);
+    setBrief('');
+    try {
+      const res = await fetch('/api/ai/morning-brief', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          followupsDue,
+          openTasks,
+          activeRoles: stats?.activeRoles ?? 0,
+          pendingCandidates: stats?.pendingCandidates ?? 0,
+        }),
+      });
+      if (!res.ok) throw new Error('Failed to generate brief');
+      const reader = res.body!.getReader();
+      const decoder = new TextDecoder();
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        setBrief((prev) => prev + decoder.decode(value));
+      }
+      setRan(true);
+    } catch {
+      setBrief('Failed to generate brief. Check your ANTHROPIC_API_KEY.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (!ran && !loading && (followupsDue.length > 0 || openTasks.length > 0 || stats)) {
+      runBrief();
+    }
+  }, [followupsDue.length, openTasks.length, stats]);
+
+  const lines = brief.split('\n');
+
+  return (
+    <div className="card p-6 border-l-4 border-l-gold">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <Sparkles size={16} className="text-gold" />
+          <h2 className="font-display font-bold text-base">Morning Brief</h2>
+          {loading && <Loader2 size={13} className="text-muted animate-spin" />}
+        </div>
+        <button
+          onClick={runBrief}
+          disabled={loading}
+          className="p-1.5 rounded-lg text-muted hover:text-fg hover:bg-elevated transition-colors disabled:opacity-40"
+          title="Refresh"
+        >
+          <RefreshCw size={13} />
+        </button>
+      </div>
+
+      {!brief && !loading && (
+        <div className="text-sm text-muted py-4 text-center">
+          Loading context…
+        </div>
+      )}
+
+      {brief && (
+        <div className="space-y-1">
+          {lines.map((line, i) => {
+            if (!line.trim()) return <div key={i} className="h-2" />;
+            if (line.startsWith('**') && line.endsWith('**')) {
+              return (
+                <p key={i} className="text-sm font-semibold text-gold mt-3 mb-1">
+                  {line.replace(/\*\*/g, '')}
+                </p>
+              );
+            }
+            if (line.startsWith('- ') || line.startsWith('• ')) {
+              return (
+                <p key={i} className="text-sm text-fg pl-3 border-l border-border">
+                  {line.replace(/^[•\-]\s/, '')}
+                </p>
+              );
+            }
+            return (
+              <p key={i} className="text-sm text-fg">
+                {line}
+              </p>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/agent/PendingApprovals.tsx
+++ b/components/agent/PendingApprovals.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { supabase, isSupabaseConfigured } from '@/lib/supabase';
+import { daysSince, formatDate } from '@/lib/utils';
+import { Badge } from '@/components/ui/Badge';
+import { Clock, Users } from 'lucide-react';
+import Link from 'next/link';
+
+export default function PendingApprovals() {
+  const enabled = isSupabaseConfigured();
+
+  const { data: pending = [] } = useQuery({
+    queryKey: ['pending-approvals'],
+    enabled,
+    queryFn: async () => {
+      const { data } = await supabase
+        .from('candidates')
+        .select('*, role:roles(title, client:clients(id, name, slack_channel))')
+        .eq('response_status', 'pending')
+        .eq('archived', false)
+        .order('intro_sent_at', { ascending: true })
+        .limit(50);
+      return data || [];
+    },
+  });
+
+  const byClient: Record<string, { clientName: string; clientId: string; slackChannel: string | null; items: any[] }> = {};
+  for (const c of pending) {
+    const clientId = c.role?.client?.id ?? 'unknown';
+    const clientName = c.role?.client?.name ?? 'Unknown client';
+    if (!byClient[clientId]) {
+      byClient[clientId] = { clientName, clientId, slackChannel: c.role?.client?.slack_channel ?? null, items: [] };
+    }
+    byClient[clientId].items.push(c);
+  }
+
+  const sorted = Object.values(byClient).sort((a, b) => b.items.length - a.items.length);
+
+  if (sorted.length === 0) return null;
+
+  return (
+    <div className="card p-6">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <Clock size={15} className="text-warning" />
+          <h2 className="font-display font-bold text-base">Pending Approvals</h2>
+        </div>
+        <span className="font-mono text-xs text-muted">{pending.length} total</span>
+      </div>
+
+      <div className="space-y-3">
+        {sorted.map(({ clientId, clientName, slackChannel, items }) => {
+          const oldest = Math.max(...items.map((c: any) => daysSince(c.intro_sent_at)));
+          const urgencyTone = oldest >= 5 ? 'danger' : oldest >= 3 ? 'warning' : 'success';
+          return (
+            <div key={clientId} className="flex items-center gap-4 px-3 py-3 rounded-lg border border-border hover:bg-elevated/30 transition-colors">
+              <div className="flex-1 min-w-0">
+                <Link href={`/clients/${clientId}`} className="font-medium text-sm hover:text-gold transition-colors">
+                  {clientName}
+                </Link>
+                <div className="flex items-center gap-2 mt-1 flex-wrap">
+                  {items.slice(0, 4).map((c: any) => (
+                    <span key={c.id} className="text-xs text-muted font-mono truncate max-w-[120px]" title={c.name}>
+                      {c.name}
+                    </span>
+                  ))}
+                  {items.length > 4 && (
+                    <span className="text-xs text-muted">+{items.length - 4} more</span>
+                  )}
+                </div>
+              </div>
+              <div className="shrink-0 flex items-center gap-3">
+                <div className="text-right">
+                  <div className="flex items-center gap-1">
+                    <Users size={11} className="text-muted" />
+                    <span className="font-mono text-sm font-medium">{items.length}</span>
+                  </div>
+                  <div className="text-[10px] text-muted">pending</div>
+                </div>
+                <Badge tone={urgencyTone}>{oldest}d max</Badge>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -14,11 +14,13 @@ import {
   Settings,
   ChevronLeft,
   ChevronRight,
+  Bot,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 const nav = [
   { href: '/', label: 'Dashboard', icon: Home },
+  { href: '/agent', label: 'AI Agent', icon: Bot },
   { href: '/tags', label: 'Slack Tags', icon: Tag },
   { href: '/jds', label: 'JD Tracker', icon: FileText },
   { href: '/emails', label: 'Email Tracker', icon: Mail },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "contrario-command-center",
       "version": "4.0.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.94.0",
         "@supabase/ssr": "^0.5.2",
         "@supabase/supabase-js": "^2.47.10",
         "@tanstack/react-query": "^5.62.11",
@@ -45,6 +46,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.94.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.94.0.tgz",
+      "integrity": "sha512-OVlCttk5MyeTGtrWX5+F3MJOfEMDuEjK8+rm9aQMDfRPWndVMbhk37QG8WLnVbcc7huyUGngVMjT7iMN2llySA==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/runtime": {
@@ -1778,6 +1799,19 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -2724,6 +2758,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.94.0",
     "@supabase/ssr": "^0.5.2",
     "@supabase/supabase-js": "^2.47.10",
     "@tanstack/react-query": "^5.62.11",


### PR DESCRIPTION
## Summary

- **`/agent` page** — New AI-powered ops hub with four sections: Morning Brief (auto-streams a ranked daily brief on load using live Supabase data), Daily Ops Checklist (7 tasks from Lucía's real workflow, persisted in localStorage, resets daily), Pending Approvals (candidates grouped by client with urgency color-coding), and a persistent AI Chat co-pilot sidebar with quick-action buttons
- **JD Quick-Create tab** — Form → Claude streams a full JD package inline: JD body, SEQ 1/2/3 outreach emails, and intro email, each with a copy-to-clipboard button and collapsible sections
- **Email Tracker upgrade** — "Draft" button on every pending candidate row; clicks stream a Contrario-voice follow-up inline (no modal) with copy-to-clipboard and regenerate
- **4 streaming API routes** using `@anthropic-ai/sdk` with `claude-sonnet-4-20250514`: `/api/ai/morning-brief`, `/api/ai/draft-followup`, `/api/ai/chat`, `/api/ai/jd-create` — all stream token-by-token via ReadableStream
- **Sidebar** — AI Agent nav item added (Bot icon, second position)

## Setup

Add to `.env.local`:
```
ANTHROPIC_API_KEY=sk-ant-...
```

## Test plan

- [ ] Set `ANTHROPIC_API_KEY` in `.env.local`
- [ ] Navigate to `/agent` — Morning Brief should auto-stream on load
- [ ] Check off items in Daily Ops Checklist; reload the page — state persists
- [ ] Open Email Tracker (`/emails`), click "Draft" on a pending candidate — inline draft streams in Contrario voice
- [ ] On `/agent`, open JD Creator tab, fill in company + role, click Generate — full package streams with copy buttons per section
- [ ] Toggle AI Co-pilot sidebar, try quick-action buttons and free-form chat

https://claude.ai/code/session_01RgonGMNBTQxy6YGAR1RR9Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01RgonGMNBTQxy6YGAR1RR9Q)_